### PR TITLE
feat: Add separate screen for reordering all apps

### DIFF
--- a/app/src/main/java/com/github/droidworksstudio/launcher/adapter/drawer/DrawAdapter.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/adapter/drawer/DrawAdapter.kt
@@ -38,8 +38,7 @@ class DrawAdapter(
             binding,
             onAppClickedListener,
             onAppLongClickedListener,
-            preferenceHelper,
-            itemTouchHelper
+            preferenceHelper
         )
     }
 

--- a/app/src/main/java/com/github/droidworksstudio/launcher/adapter/drawer/DrawOrderAdapter.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/adapter/drawer/DrawOrderAdapter.kt
@@ -1,0 +1,72 @@
+package com.github.droidworksstudio.launcher.adapter.drawer
+
+import android.util.Log
+import android.view.LayoutInflater
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.github.droidworksstudio.launcher.data.entities.AppInfo
+import com.github.droidworksstudio.launcher.databinding.ItemFavoriteBinding
+import com.github.droidworksstudio.launcher.helper.PreferenceHelper
+import com.github.droidworksstudio.launcher.listener.OnItemClickedListener
+import com.github.droidworksstudio.launcher.listener.OnItemMoveListener
+import com.github.droidworksstudio.launcher.ui.drawer.DrawOrderViewHolder
+
+class DrawOrderAdapter(
+    private val onAppClickedListener:
+    OnItemClickedListener.OnAppsClickedListener,
+    private val preferenceHelperProvider: PreferenceHelper
+) : ListAdapter<AppInfo, RecyclerView.ViewHolder>(DiffCallback()),
+    OnItemMoveListener.OnItemActionListener {
+
+    private var touchHelper: ItemTouchHelper? = null
+
+    override fun onCreateViewHolder(
+        parent: android.view.ViewGroup,
+        viewType: Int
+    ): RecyclerView.ViewHolder {
+        val binding = ItemFavoriteBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        val preferenceHelper = preferenceHelperProvider
+        return DrawOrderViewHolder(
+            binding,
+            onAppClickedListener,
+            preferenceHelper,
+            touchHelper
+        )
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val currentItem = getItem(position)
+        when (holder) {
+            is DrawOrderViewHolder -> {
+                holder.bind(currentItem)
+            }
+        }
+    }
+
+    class DiffCallback : androidx.recyclerview.widget.DiffUtil.ItemCallback<AppInfo>() {
+        override fun areItemsTheSame(oldItem: AppInfo, newItem: AppInfo) =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: AppInfo, newItem: AppInfo) =
+            oldItem == newItem
+    }
+
+    fun setItemTouchHelper(touchHelper: ItemTouchHelper) {
+        this.touchHelper = touchHelper
+    }
+
+    override fun onViewMoved(oldPosition: Int, newPosition: Int): Boolean {
+        Log.d("Tag", "List Adapter$newPosition")
+        return false
+    }
+
+    override fun onViewSwiped(position: Int) {
+        Log.d("Tag", "onViewMoved")
+    }
+
+}

--- a/app/src/main/java/com/github/droidworksstudio/launcher/data/dao/AppInfoDAO.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/data/dao/AppInfoDAO.kt
@@ -37,7 +37,7 @@ interface AppInfoDAO {
     @Query("SELECT * FROM app ORDER BY app_name COLLATE NOCASE ASC")
     fun getAllAppsFlow(): Flow<List<AppInfo>>
 
-    @Query("SELECT * FROM app WHERE is_hidden = 0 ORDER BY app_name COLLATE NOCASE ASC")
+    @Query("SELECT * FROM app WHERE is_hidden = 0 ORDER BY app_order ASC, app_name COLLATE NOCASE ASC")
     fun getDrawAppsFlow(): Flow<List<AppInfo>>
 
     @Query("SELECT * FROM app WHERE is_favorite = 1 ORDER BY app_order ASC, id ASC")

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/drawer/DrawOrderFragment.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/drawer/DrawOrderFragment.kt
@@ -19,9 +19,9 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.github.droidworksstudio.common.launchApp
 import com.github.droidworksstudio.common.showLongToast
 import com.github.droidworksstudio.launcher.R
-import com.github.droidworksstudio.launcher.adapter.drawer.DrawAdapter
+import com.github.droidworksstudio.launcher.adapter.drawer.DrawOrderAdapter
 import com.github.droidworksstudio.launcher.data.entities.AppInfo
-import com.github.droidworksstudio.launcher.databinding.FragmentDrawModBinding
+import com.github.droidworksstudio.launcher.databinding.FragmentDrawOrderBinding
 import com.github.droidworksstudio.launcher.helper.AppHelper
 import com.github.droidworksstudio.launcher.helper.BiometricHelper
 import com.github.droidworksstudio.launcher.helper.PreferenceHelper
@@ -36,14 +36,13 @@ import javax.inject.Inject
 
 
 @AndroidEntryPoint
-class DrawFragmentMod : Fragment(),
+class DrawOrderFragment : Fragment(),
     OnItemClickedListener.OnAppsClickedListener,
-    OnItemClickedListener.OnAppLongClickedListener,
     OnItemClickedListener.OnAppStateClickListener,
     OnItemClickedListener.BottomSheetDismissListener,
     OnItemMoveListener.OnItemActionListener,
     BiometricHelper.Callback {
-    private var _binding: FragmentDrawModBinding? = null
+    private var _binding: FragmentDrawOrderBinding? = null
 
     private val binding get() = _binding!!
 
@@ -60,43 +59,40 @@ class DrawFragmentMod : Fragment(),
     @Inject
     lateinit var appHelper: AppHelper
 
-    private val drawAdapter: DrawAdapter by lazy { DrawAdapter(this, this, preferenceHelper) }
+    private val drawOrderAdapter: DrawOrderAdapter by lazy { DrawOrderAdapter(this, preferenceHelper) }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-
-        _binding = FragmentDrawModBinding.inflate(inflater, container, false)
+        _binding = FragmentDrawOrderBinding.inflate(inflater, container, false)
         return binding.root
-
     }
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        appHelper.dayNightMod(requireContext(), binding.drawView)
+        appHelper.dayNightMod(requireContext(), binding.drawOrderView)
         super.onViewCreated(view, savedInstanceState)
 
         context = requireContext()
 
         setupRecyclerView()
-        observeFavorite()
+        observeDrawApps()
         observeHomeAppOrder()
         observeSwipeTouchListener()
     }
 
     private fun setupRecyclerView() {
-
-        binding.drawAdapter.apply {
-            adapter = drawAdapter
+        binding.drawOrderAdapter.apply {
+            adapter = drawOrderAdapter
             layoutManager = StaggeredGridLayoutManager(1, StaggeredGridLayoutManager.VERTICAL)
             setHasFixedSize(false)
         }
     }
 
     private fun handleDragAndDrop(oldPosition: Int, newPosition: Int) {
-        val items = drawAdapter.currentList.toMutableList()
+        val items = drawOrderAdapter.currentList.toMutableList()
         Collections.swap(items, oldPosition, newPosition)
 
         items.forEachIndexed { index, appInfo ->
@@ -109,11 +105,11 @@ class DrawFragmentMod : Fragment(),
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
-    private fun observeFavorite() {
+    private fun observeDrawApps() {
         viewModel.compareInstalledAppInfo()
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.drawApps.collect {
-                drawAdapter.submitList(it)
+                drawOrderAdapter.submitList(it)
                 updateNoAppsTextViewVisibility(it.isEmpty())
             }
         }
@@ -122,16 +118,16 @@ class DrawFragmentMod : Fragment(),
     private fun updateNoAppsTextViewVisibility(isEmpty: Boolean) {
         if (isEmpty) {
             binding.noApps.visibility = View.VISIBLE
-            binding.drawAdapter.visibility = View.GONE
+            binding.drawOrderAdapter.visibility = View.GONE
         } else {
             binding.noApps.visibility = View.GONE
-            binding.drawAdapter.visibility = View.VISIBLE
+            binding.drawOrderAdapter.visibility = View.VISIBLE
         }
     }
 
     private fun observeHomeAppOrder() {
-        binding.drawAdapter.adapter = drawAdapter
-        val listener: OnItemMoveListener.OnItemActionListener = drawAdapter
+        binding.drawOrderAdapter.adapter = drawOrderAdapter
+        val listener: OnItemMoveListener.OnItemActionListener = drawOrderAdapter
 
         val simpleItemTouchCallback = object : ItemTouchHelper.Callback() {
 
@@ -175,7 +171,6 @@ class DrawFragmentMod : Fragment(),
                     viewHolder.bindingAdapterPosition,
                     target.bindingAdapterPosition
                 )
-
             }
 
             override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
@@ -188,15 +183,15 @@ class DrawFragmentMod : Fragment(),
 
         val itemTouchHelper = ItemTouchHelper(simpleItemTouchCallback)
 
-        drawAdapter.setItemTouchHelper(itemTouchHelper)
-        itemTouchHelper.attachToRecyclerView(binding.drawAdapter)
+        drawOrderAdapter.setItemTouchHelper(itemTouchHelper)
+        itemTouchHelper.attachToRecyclerView(binding.drawOrderAdapter)
     }
 
     @SuppressLint("ClickableViewAccessibility")
     private fun observeSwipeTouchListener() {
         binding.apply {
             fragmentContainer.setOnTouchListener(getSwipeGestureListener(context))
-            drawAdapter.setOnTouchListener(getSwipeGestureListener(context))
+            drawOrderAdapter.setOnTouchListener(getSwipeGestureListener(context))
         }
     }
 
@@ -250,13 +245,5 @@ class DrawFragmentMod : Fragment(),
 
     override fun onViewMoved(oldPosition: Int, newPosition: Int): Boolean {
         return true
-    }
-
-    override fun onAppLongClicked(appInfo: AppInfo) {
-        //
-    }
-
-    override fun onBottomSheetDismissed() {
-        //
     }
 }

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/drawer/DrawOrderViewHolder.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/drawer/DrawOrderViewHolder.kt
@@ -1,0 +1,64 @@
+package com.github.droidworksstudio.launcher.ui.drawer
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.view.MotionEvent
+import android.view.View
+import androidx.appcompat.widget.LinearLayoutCompat
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+import com.github.droidworksstudio.launcher.data.entities.AppInfo
+import com.github.droidworksstudio.launcher.databinding.ItemFavoriteBinding
+import com.github.droidworksstudio.launcher.helper.PreferenceHelper
+import com.github.droidworksstudio.launcher.listener.OnItemClickedListener
+
+@SuppressLint("ClickableViewAccessibility")
+class DrawOrderViewHolder(
+    private val binding: ItemFavoriteBinding,
+    private val onAppClickedListener: OnItemClickedListener.OnAppsClickedListener,
+    private val preferenceHelper: PreferenceHelper,
+    private val touchHelper: ItemTouchHelper?,
+) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    init {
+        binding.appFavoriteDragIcon.setOnTouchListener { _, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                touchHelper?.startDrag(this)
+            }
+            false
+        }
+    }
+
+    fun bind(appInfo: AppInfo) {
+        binding.apply {
+            // Get the current LayoutParams of appFavoriteName
+            val layoutParams = appFavoriteName.layoutParams as LinearLayoutCompat.LayoutParams
+
+            // Set the margins
+            layoutParams.topMargin = preferenceHelper.homeAppPadding.toInt()
+            layoutParams.bottomMargin = preferenceHelper.homeAppPadding.toInt()
+
+            appFavoriteName.layoutParams = layoutParams
+            appFavoriteName.text = appInfo.appName
+            appFavoriteName.setTextColor(preferenceHelper.appColor)
+            appFavoriteName.textSize = preferenceHelper.appTextSize
+            Log.d("Tag", "Draw Order Adapter: ${appInfo.appName}")
+
+            if (preferenceHelper.showAppIcon) {
+                val appIcon =
+                    binding.root.context.packageManager.getApplicationIcon(appInfo.packageName)
+                appFavoriteLeftIcon.setImageDrawable(appIcon)
+                appFavoriteLeftIcon.layoutParams.width =
+                    preferenceHelper.appTextSize.toInt() * 3
+                appFavoriteLeftIcon.layoutParams.height =
+                    preferenceHelper.appTextSize.toInt() * 3
+                appFavoriteLeftIcon.visibility = View.VISIBLE
+            }
+        }
+
+        itemView.setOnClickListener {
+            onAppClickedListener.onAppClicked(appInfo)
+        }
+    }
+}

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/drawer/DrawViewHolder.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/drawer/DrawViewHolder.kt
@@ -13,8 +13,6 @@ import com.github.droidworksstudio.launcher.R
 import com.github.droidworksstudio.launcher.data.entities.AppInfo
 import com.github.droidworksstudio.launcher.databinding.ItemDrawBinding
 import com.github.droidworksstudio.launcher.helper.PreferenceHelper
-import android.annotation.SuppressLint
-import androidx.recyclerview.widget.ItemTouchHelper
 import com.github.droidworksstudio.launcher.listener.OnItemClickedListener
 import com.github.droidworksstudio.launcher.utils.Constants
 
@@ -23,23 +21,12 @@ class DrawViewHolder(
     private val onAppClickedListener: OnItemClickedListener.OnAppsClickedListener,
     private val onAppLongClickedListener: OnItemClickedListener.OnAppLongClickedListener,
     private val preferenceHelper: PreferenceHelper,
-    private val itemTouchHelper: ItemTouchHelper,
 ) :
 
     RecyclerView.ViewHolder(binding.root) {
 
-    @SuppressLint("ClickableViewAccessibility")
     fun bind(appInfo: AppInfo) {
         binding.apply {
-            if (preferenceHelper.allAppsSorting) {
-                appDrawDragIcon.visibility = View.VISIBLE
-                appDrawDragIcon.setOnTouchListener { _, _ ->
-                    itemTouchHelper.startDrag(this@DrawViewHolder)
-                    true
-                }
-            } else {
-                appDrawDragIcon.visibility = View.GONE
-            }
             // Get the current LayoutParams of appHiddenName
             val layoutAppNameParams = appDrawName.layoutParams as LinearLayoutCompat.LayoutParams
 

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/settings/SettingsFragment.kt
@@ -90,7 +90,7 @@ class SettingsFragment : Fragment(),
             }
 
         binding.allApps.setOnClickListener {
-            navController.navigate(R.id.DrawFragmentMod)
+            navController.navigate(R.id.DrawOrderFragment)
         }
 
             advancedSettings.setOnClickListener {

--- a/app/src/main/res/layout/fragment_draw_mod.xml
+++ b/app/src/main/res/layout/fragment_draw_mod.xml
@@ -28,7 +28,7 @@
             android:layout_height="match_parent"
             android:layout_marginVertical="20dp"
             android:gravity="center"
-            android:text="@string/hidden_fragment_no_apps"
+            android.text="@string/hidden_fragment_no_apps"
             android:textSize="@dimen/text_super_large"
             android:visibility="gone" />
 

--- a/app/src/main/res/layout/fragment_draw_order.xml
+++ b/app/src/main/res/layout/fragment_draw_order.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/draw_order_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.drawer.DrawOrderFragment">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginVertical="32dp"
+        android:clickable="true"
+        android:focusable="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/topTextView"
+            style="@style/TextDefaultStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="20dp"
+            android:text="@string/draw_fragment_name"
+            android:textSize="@dimen/text_super_large"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/drawOrderAdapter"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="92dp"
+            app:layout_constraintTop_toBottomOf="@id/topTextView" />
+
+        <TextView
+            android:id="@+id/noApps"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="92dp"
+            android:text="@string/hidden_fragment_no_apps"
+            android:textSize="18sp"
+            android:visibility="gone" />
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_draw.xml
+++ b/app/src/main/res/layout/item_draw.xml
@@ -28,14 +28,5 @@
             android:gravity="center"
             android:textSize="24sp" />
 
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/appDraw_drag_icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_gravity="center"
-            android:layout_marginHorizontal="16dp"
-            android:background="@drawable/icon_favorite_order"
-            android:visibility="gone" />
-
     </androidx.appcompat.widget.LinearLayoutCompat>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -70,4 +70,10 @@
         android:label="@string/draw_fragment_label"
         tools:layout="@layout/fragment_draw_mod" />
 
+    <fragment
+        android:id="@+id/DrawOrderFragment"
+        android:name="com.github.droidworksstudio.launcher.ui.drawer.DrawOrderFragment"
+        android:label="DrawOrderFragment"
+        tools:layout="@layout/fragment_draw_order" />
+
 </navigation>


### PR DESCRIPTION
This commit implements a new, dedicated screen for reordering the 'All Apps' list, following detailed user specifications. This is a significant change from the initial implementation.

Changes include:
- Created `DrawOrderFragment`, `DrawOrderAdapter`, and `DrawOrderViewHolder` to build the new reordering screen.
- The layout for the reordering screen reuses `item_favorite.xml` for consistency and efficiency.
- Updated the `nav_graph.xml` to include the new `DrawOrderFragment`.
- Modified `SettingsFragment` to navigate to the new reordering screen from the 'All Apps' button.
- Updated the Room DAO query for `getDrawAppsFlow` to sort by `app_order`, ensuring the main app drawer respects the new custom order.
- Verified that the existing backup/restore functionality correctly handles the `appOrder` property without modification.