### PR TITLE
Reduce navigation back stack churn to avoid large saved state

### DIFF
--- a/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
@@ -432,14 +432,22 @@ class AppHelper @Inject constructor() {
     }
 
     fun getActionType(actionType: Constants.Swipe): NavOptions {
-        return when (actionType) {
-            Constants.Swipe.DoubleTap -> {
+        return buildNavOptions(actionType)
+    }
+
+    fun buildNavOptions(
+        actionType: Constants.Swipe,
+        popUpToId: Int? = null,
+        popUpToInclusive: Boolean = false,
+        launchSingleTop: Boolean = false,
+    ): NavOptions {
+        val builder = when (actionType) {
+            Constants.Swipe.DoubleTap, Constants.Swipe.WordTap -> {
                 NavOptions.Builder()
                     .setEnterAnim(R.anim.zoom_in)
                     .setExitAnim(R.anim.zoom_out)
                     .setPopEnterAnim(R.anim.zoom_in)
                     .setPopExitAnim(R.anim.zoom_out)
-                    .build()
             }
 
             Constants.Swipe.Up -> {
@@ -448,7 +456,6 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_top)
                     .setPopEnterAnim(R.anim.slide_in_bottom)
                     .setPopExitAnim(R.anim.slide_out_bottom)
-                    .build()
             }
 
             Constants.Swipe.Down -> {
@@ -457,7 +464,6 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_bottom)
                     .setPopEnterAnim(R.anim.slide_in_top)
                     .setPopExitAnim(R.anim.slide_out_top)
-                    .build()
             }
 
             Constants.Swipe.Left -> {
@@ -466,7 +472,6 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_right)
                     .setPopEnterAnim(R.anim.slide_in_left)
                     .setPopExitAnim(R.anim.slide_out_left)
-                    .build()
             }
 
             Constants.Swipe.Right -> {
@@ -475,18 +480,18 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_left)
                     .setPopEnterAnim(R.anim.slide_in_right)
                     .setPopExitAnim(R.anim.slide_out_right)
-                    .build()
-            }
-
-            Constants.Swipe.WordTap -> {
-                NavOptions.Builder()
-                    .setEnterAnim(R.anim.zoom_in)
-                    .setExitAnim(R.anim.zoom_out)
-                    .setPopEnterAnim(R.anim.zoom_in)
-                    .setPopExitAnim(R.anim.zoom_out)
-                    .build()
             }
         }
+
+        if (popUpToId != null) {
+            builder.setPopUpTo(popUpToId, popUpToInclusive)
+        }
+
+        if (launchSingleTop) {
+            builder.setLaunchSingleTop(true)
+        }
+
+        return builder.build()
     }
 
     sealed class WeatherResult {

--- a/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
@@ -483,15 +483,12 @@ class AppHelper @Inject constructor() {
             }
         }
 
-        if (popUpToId != null) {
-            builder.setPopUpTo(popUpToId, popUpToInclusive)
-        }
-
-        if (launchSingleTop) {
-            builder.setLaunchSingleTop(true)
-        }
-
-        return builder.build()
+        return builder.apply {
+            popUpToId?.let { setPopUpTo(it, popUpToInclusive) }
+            if (launchSingleTop) {
+                setLaunchSingleTop(true)
+            }
+        }.build()
     }
 
     sealed class WeatherResult {

--- a/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
@@ -485,19 +485,15 @@ class AppHelper @Inject constructor() {
             }
         }
 
-        if (popUpToId != null) {
-            builder.setPopUpTo(popUpToId, popUpToInclusive, saveState)
-        }
-
-        if (launchSingleTop) {
-            builder.setLaunchSingleTop(true)
-        }
-
-        if (restoreState) {
-            builder.setRestoreState(true)
-        }
-
-        return builder.build()
+        return builder.apply {
+            popUpToId?.let { setPopUpTo(it, popUpToInclusive, saveState) }
+            if (launchSingleTop) {
+                setLaunchSingleTop(true)
+            }
+            if (restoreState) {
+                setRestoreState(true)
+            }
+        }.build()
     }
 
     sealed class WeatherResult {

--- a/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
@@ -440,6 +440,8 @@ class AppHelper @Inject constructor() {
         popUpToId: Int? = null,
         popUpToInclusive: Boolean = false,
         launchSingleTop: Boolean = false,
+        saveState: Boolean = false,
+        restoreState: Boolean = false,
     ): NavOptions {
         val builder = when (actionType) {
             Constants.Swipe.DoubleTap, Constants.Swipe.WordTap -> {
@@ -483,12 +485,19 @@ class AppHelper @Inject constructor() {
             }
         }
 
-        return builder.apply {
-            popUpToId?.let { setPopUpTo(it, popUpToInclusive) }
-            if (launchSingleTop) {
-                setLaunchSingleTop(true)
-            }
-        }.build()
+        if (popUpToId != null) {
+            builder.setPopUpTo(popUpToId, popUpToInclusive, saveState)
+        }
+
+        if (launchSingleTop) {
+            builder.setLaunchSingleTop(true)
+        }
+
+        if (restoreState) {
+            builder.setRestoreState(true)
+        }
+
+        return builder.build()
     }
 
     sealed class WeatherResult {

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -359,29 +359,24 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             }
 
             R.id.SettingsFragment -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHome()
             }
 
             else -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHome()
+            }
+        }
+    }
+
+    private fun navigateToHome() {
+        Handler(Looper.getMainLooper()).post {
+            if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
+                navController.navigate(
+                    R.id.HomeFragment,
+                    null,
+                    actionTypeNavOptions
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -388,11 +388,12 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
 
     private fun navOptionsFor(actionType: Constants.Swipe, popUpToId: Int? = null): NavOptions {
         return if (preferenceHelper.disableAnimations) {
-            val builder = NavOptions.Builder().setLaunchSingleTop(true)
-            if (popUpToId != null) {
-                builder.setPopUpTo(popUpToId, false)
-            }
-            builder.build()
+            return NavOptions.Builder()
+                .setLaunchSingleTop(true)
+                .apply {
+                    popUpToId?.let { setPopUpTo(it, false) }
+                }
+                .build()
         } else {
             appHelper.buildNavOptions(
                 actionType = actionType,

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -326,7 +326,13 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
         navController = findNavController(R.id.nav_host_fragment_content_main)
         when (navController.currentDestination?.id) {
             R.id.HomeFragment -> return
-            else -> navController.navigate(R.id.HomeFragment)
+            else -> {
+                val popped = navController.popBackStack(R.id.HomeFragment, false)
+                if (!popped) {
+                    val navOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
+                    navController.navigate(R.id.HomeFragment, null, navOptions)
+                }
+            }
         }
     }
 
@@ -340,46 +346,60 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             R.id.FavoriteFragment,
             R.id.HiddenFragment,
                 -> {
-                val actionTypeNavOptions: NavOptions? =
-                    if (preferenceHelper.disableAnimations) null
-                    else appHelper.getActionType(Constants.Swipe.Up)
-
                 Handler(Looper.getMainLooper()).post {
-                    navController.navigate(
-                        R.id.SettingsFragment,
-                        null,
-                        actionTypeNavOptions
-                    )
+                    if (!navController.popBackStack(R.id.SettingsFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, R.id.SettingsFragment)
+                        navController.navigate(
+                            R.id.SettingsFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
             }
 
             R.id.SettingsFragment -> {
-                val actionTypeNavOptions: NavOptions? =
-                    if (preferenceHelper.disableAnimations) null
-                    else appHelper.getActionType(Constants.Swipe.Up)
-
                 Handler(Looper.getMainLooper()).post {
-                    navController.navigate(
-                        R.id.HomeFragment,
-                        null,
-                        actionTypeNavOptions
-                    )
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
             }
 
             else -> {
-                val actionTypeNavOptions: NavOptions? =
-                    if (preferenceHelper.disableAnimations) null
-                    else appHelper.getActionType(Constants.Swipe.Up)
-
                 Handler(Looper.getMainLooper()).post {
-                    navController.navigate(
-                        R.id.HomeFragment,
-                        null,
-                        actionTypeNavOptions
-                    )
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
             }
+        }
+    }
+
+    private fun navOptionsFor(actionType: Constants.Swipe, popUpToId: Int? = null): NavOptions {
+        return if (preferenceHelper.disableAnimations) {
+            val builder = NavOptions.Builder().setLaunchSingleTop(true)
+            if (popUpToId != null) {
+                builder.setPopUpTo(popUpToId, false)
+            }
+            builder.build()
+        } else {
+            appHelper.buildNavOptions(
+                actionType = actionType,
+                popUpToId = popUpToId,
+                popUpToInclusive = false,
+                launchSingleTop = true
+            )
         }
     }
 

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -388,7 +388,7 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
 
     private fun navOptionsFor(actionType: Constants.Swipe, popUpToId: Int? = null): NavOptions {
         return if (preferenceHelper.disableAnimations) {
-            return NavOptions.Builder()
+            NavOptions.Builder()
                 .setLaunchSingleTop(true)
                 .apply {
                     popUpToId?.let { setPopUpTo(it, false) }

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -369,39 +369,29 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             }
 
             R.id.SettingsFragment -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(
-                            actionType = Constants.Swipe.Up,
-                            popUpToId = navController.graph.startDestinationId,
-                            saveState = true,
-                            restoreState = true
-                        )
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHomeFromSettings()
             }
 
             else -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(
-                            actionType = Constants.Swipe.Up,
-                            popUpToId = navController.graph.startDestinationId,
-                            saveState = true,
-                            restoreState = true
-                        )
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHomeFromSettings()
+            }
+        }
+    }
+
+    private fun navigateToHomeFromSettings() {
+        Handler(Looper.getMainLooper()).post {
+            if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                val actionTypeNavOptions = navOptionsFor(
+                    actionType = Constants.Swipe.Up,
+                    popUpToId = navController.graph.startDestinationId,
+                    saveState = true,
+                    restoreState = true
+                )
+                navController.navigate(
+                    R.id.HomeFragment,
+                    null,
+                    actionTypeNavOptions
+                )
             }
         }
     }
@@ -413,14 +403,15 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
         restoreState: Boolean = false,
     ): NavOptions {
         return if (preferenceHelper.disableAnimations) {
-            val builder = NavOptions.Builder().setLaunchSingleTop(true)
-            if (popUpToId != null) {
-                builder.setPopUpTo(popUpToId, false, saveState)
-            }
-            if (restoreState) {
-                builder.setRestoreState(true)
-            }
-            builder.build()
+            NavOptions.Builder()
+                .setLaunchSingleTop(true)
+                .apply {
+                    popUpToId?.let { setPopUpTo(it, false, saveState) }
+                    if (restoreState) {
+                        setRestoreState(true)
+                    }
+                }
+                .build()
         } else {
             appHelper.buildNavOptions(
                 actionType = actionType,

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -329,7 +329,12 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             else -> {
                 val popped = navController.popBackStack(R.id.HomeFragment, false)
                 if (!popped) {
-                    val navOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
+                    val navOptions = navOptionsFor(
+                        actionType = Constants.Swipe.Up,
+                        popUpToId = navController.graph.startDestinationId,
+                        saveState = true,
+                        restoreState = true
+                    )
                     navController.navigate(R.id.HomeFragment, null, navOptions)
                 }
             }
@@ -348,7 +353,12 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
                 -> {
                 Handler(Looper.getMainLooper()).post {
                     if (!navController.popBackStack(R.id.SettingsFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, R.id.SettingsFragment)
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = R.id.SettingsFragment,
+                            saveState = true,
+                            restoreState = true
+                        )
                         navController.navigate(
                             R.id.SettingsFragment,
                             null,
@@ -359,42 +369,66 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             }
 
             R.id.SettingsFragment -> {
-                navigateToHome()
+                Handler(Looper.getMainLooper()).post {
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = navController.graph.startDestinationId,
+                            saveState = true,
+                            restoreState = true
+                        )
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
+                }
             }
 
             else -> {
-                navigateToHome()
-            }
-        }
-    }
-
-    private fun navigateToHome() {
-        Handler(Looper.getMainLooper()).post {
-            if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
-                navController.navigate(
-                    R.id.HomeFragment,
-                    null,
-                    actionTypeNavOptions
-                )
-            }
-        }
-    }
-
-    private fun navOptionsFor(actionType: Constants.Swipe, popUpToId: Int? = null): NavOptions {
-        return if (preferenceHelper.disableAnimations) {
-            NavOptions.Builder()
-                .setLaunchSingleTop(true)
-                .apply {
-                    popUpToId?.let { setPopUpTo(it, false) }
+                Handler(Looper.getMainLooper()).post {
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = navController.graph.startDestinationId,
+                            saveState = true,
+                            restoreState = true
+                        )
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
-                .build()
+            }
+        }
+    }
+
+    private fun navOptionsFor(
+        actionType: Constants.Swipe,
+        popUpToId: Int? = null,
+        saveState: Boolean = false,
+        restoreState: Boolean = false,
+    ): NavOptions {
+        return if (preferenceHelper.disableAnimations) {
+            val builder = NavOptions.Builder().setLaunchSingleTop(true)
+            if (popUpToId != null) {
+                builder.setPopUpTo(popUpToId, false, saveState)
+            }
+            if (restoreState) {
+                builder.setRestoreState(true)
+            }
+            builder.build()
         } else {
             appHelper.buildNavOptions(
                 actionType = actionType,
                 popUpToId = popUpToId,
                 popUpToInclusive = false,
-                launchSingleTop = true
+                launchSingleTop = true,
+                saveState = saveState,
+                restoreState = restoreState
             )
         }
     }


### PR DESCRIPTION
### Motivation
- Crash reports showed `TransactionTooLargeException` caused by very large saved state (nav back stack / fragment state), so navigation should avoid stacking duplicate destinations and support `popUpTo`/single-top semantics.  
- The change aims to reduce saved-state size by popping back to existing destinations instead of repeatedly navigating to new copies.

### Description
- Added `buildNavOptions` in `AppHelper.kt` to produce `NavOptions` with `popUpToId`, `popUpToInclusive` and `launchSingleTop` while preserving existing animations, and made `getActionType` forward to it.  
- Reworked `MainActivity.kt` navigation helpers to attempt `popBackStack` to `HomeFragment`/`SettingsFragment` before calling `navigate`, preventing duplicate fragments on the back stack.  
- Added `navOptionsFor` helper in `MainActivity.kt` that selects either a minimal `NavOptions` (when `preferenceHelper.disableAnimations` is true) or `appHelper.buildNavOptions` with `launchSingleTop=true`.  
- Replaced direct `navigate` calls with conditional `popBackStack` + `navigate` flows to reduce back stack churn and therefore saved `Bundle` size.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979a46ad26483329f324bea548d71b2)