### PR TITLE
Extract navigateToHome helper in MainActivity

### DIFF
--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -359,29 +359,24 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             }
 
             R.id.SettingsFragment -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHome()
             }
 
             else -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHome()
+            }
+        }
+    }
+
+    private fun navigateToHome() {
+        Handler(Looper.getMainLooper()).post {
+            if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
+                navController.navigate(
+                    R.id.HomeFragment,
+                    null,
+                    actionTypeNavOptions
+                )
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Remove duplicated navigation-to-home code in `MainActivity` to improve maintainability and reduce repeated `Handler`/`popBackStack` logic.
- Centralize the home navigation behavior so future changes only need to be made in one place.

### Description
- Added a private helper `navigateToHome()` that posts to the main looper, attempts `navController.popBackStack(R.id.HomeFragment, false)`, and otherwise navigates to `R.id.HomeFragment` using `navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)`.
- Replaced the duplicated `Handler(Looper.getMainLooper())` blocks in `goBackToSettings()` for the `R.id.SettingsFragment` and `else` branches with calls to `navigateToHome()`.
- Placed the new helper adjacent to the other navigation/helper methods (after `goBackToSettings()` and before `navOptionsFor`).
- No functional behavior changes were introduced beyond consolidating duplicated code.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a2f21302c833298de854b39dd6e30)