### PR TITLE
Preserve nav state when returning Home/Settings

### DIFF
--- a/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
@@ -432,14 +432,24 @@ class AppHelper @Inject constructor() {
     }
 
     fun getActionType(actionType: Constants.Swipe): NavOptions {
-        return when (actionType) {
-            Constants.Swipe.DoubleTap -> {
+        return buildNavOptions(actionType)
+    }
+
+    fun buildNavOptions(
+        actionType: Constants.Swipe,
+        popUpToId: Int? = null,
+        popUpToInclusive: Boolean = false,
+        launchSingleTop: Boolean = false,
+        saveState: Boolean = false,
+        restoreState: Boolean = false,
+    ): NavOptions {
+        val builder = when (actionType) {
+            Constants.Swipe.DoubleTap, Constants.Swipe.WordTap -> {
                 NavOptions.Builder()
                     .setEnterAnim(R.anim.zoom_in)
                     .setExitAnim(R.anim.zoom_out)
                     .setPopEnterAnim(R.anim.zoom_in)
                     .setPopExitAnim(R.anim.zoom_out)
-                    .build()
             }
 
             Constants.Swipe.Up -> {
@@ -448,7 +458,6 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_top)
                     .setPopEnterAnim(R.anim.slide_in_bottom)
                     .setPopExitAnim(R.anim.slide_out_bottom)
-                    .build()
             }
 
             Constants.Swipe.Down -> {
@@ -457,7 +466,6 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_bottom)
                     .setPopEnterAnim(R.anim.slide_in_top)
                     .setPopExitAnim(R.anim.slide_out_top)
-                    .build()
             }
 
             Constants.Swipe.Left -> {
@@ -466,7 +474,6 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_right)
                     .setPopEnterAnim(R.anim.slide_in_left)
                     .setPopExitAnim(R.anim.slide_out_left)
-                    .build()
             }
 
             Constants.Swipe.Right -> {
@@ -475,18 +482,22 @@ class AppHelper @Inject constructor() {
                     .setExitAnim(R.anim.slide_out_left)
                     .setPopEnterAnim(R.anim.slide_in_right)
                     .setPopExitAnim(R.anim.slide_out_right)
-                    .build()
-            }
-
-            Constants.Swipe.WordTap -> {
-                NavOptions.Builder()
-                    .setEnterAnim(R.anim.zoom_in)
-                    .setExitAnim(R.anim.zoom_out)
-                    .setPopEnterAnim(R.anim.zoom_in)
-                    .setPopExitAnim(R.anim.zoom_out)
-                    .build()
             }
         }
+
+        if (popUpToId != null) {
+            builder.setPopUpTo(popUpToId, popUpToInclusive, saveState)
+        }
+
+        if (launchSingleTop) {
+            builder.setLaunchSingleTop(true)
+        }
+
+        if (restoreState) {
+            builder.setRestoreState(true)
+        }
+
+        return builder.build()
     }
 
     sealed class WeatherResult {

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -326,7 +326,18 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
         navController = findNavController(R.id.nav_host_fragment_content_main)
         when (navController.currentDestination?.id) {
             R.id.HomeFragment -> return
-            else -> navController.navigate(R.id.HomeFragment)
+            else -> {
+                val popped = navController.popBackStack(R.id.HomeFragment, false)
+                if (!popped) {
+                    val navOptions = navOptionsFor(
+                        actionType = Constants.Swipe.Up,
+                        popUpToId = navController.graph.startDestinationId,
+                        saveState = true,
+                        restoreState = true
+                    )
+                    navController.navigate(R.id.HomeFragment, null, navOptions)
+                }
+            }
         }
     }
 
@@ -340,46 +351,85 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             R.id.FavoriteFragment,
             R.id.HiddenFragment,
                 -> {
-                val actionTypeNavOptions: NavOptions? =
-                    if (preferenceHelper.disableAnimations) null
-                    else appHelper.getActionType(Constants.Swipe.Up)
-
                 Handler(Looper.getMainLooper()).post {
-                    navController.navigate(
-                        R.id.SettingsFragment,
-                        null,
-                        actionTypeNavOptions
-                    )
+                    if (!navController.popBackStack(R.id.SettingsFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = R.id.SettingsFragment,
+                            saveState = true,
+                            restoreState = true
+                        )
+                        navController.navigate(
+                            R.id.SettingsFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
             }
 
             R.id.SettingsFragment -> {
-                val actionTypeNavOptions: NavOptions? =
-                    if (preferenceHelper.disableAnimations) null
-                    else appHelper.getActionType(Constants.Swipe.Up)
-
                 Handler(Looper.getMainLooper()).post {
-                    navController.navigate(
-                        R.id.HomeFragment,
-                        null,
-                        actionTypeNavOptions
-                    )
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = navController.graph.startDestinationId,
+                            saveState = true,
+                            restoreState = true
+                        )
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
             }
 
             else -> {
-                val actionTypeNavOptions: NavOptions? =
-                    if (preferenceHelper.disableAnimations) null
-                    else appHelper.getActionType(Constants.Swipe.Up)
-
                 Handler(Looper.getMainLooper()).post {
-                    navController.navigate(
-                        R.id.HomeFragment,
-                        null,
-                        actionTypeNavOptions
-                    )
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = navController.graph.startDestinationId,
+                            saveState = true,
+                            restoreState = true
+                        )
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
             }
+        }
+    }
+
+    private fun navOptionsFor(
+        actionType: Constants.Swipe,
+        popUpToId: Int? = null,
+        saveState: Boolean = false,
+        restoreState: Boolean = false,
+    ): NavOptions {
+        return if (preferenceHelper.disableAnimations) {
+            val builder = NavOptions.Builder().setLaunchSingleTop(true)
+            if (popUpToId != null) {
+                builder.setPopUpTo(popUpToId, false, saveState)
+            }
+            if (restoreState) {
+                builder.setRestoreState(true)
+            }
+            builder.build()
+        } else {
+            appHelper.buildNavOptions(
+                actionType = actionType,
+                popUpToId = popUpToId,
+                popUpToInclusive = false,
+                launchSingleTop = true,
+                saveState = saveState,
+                restoreState = restoreState
+            )
         }
     }
 


### PR DESCRIPTION
### Motivation
- Navigation was creating brief placeholder flashes and increasing saved state size by repeatedly pushing duplicate destinations onto the back stack, so pop/save/restore semantics are needed to reuse existing destinations and avoid visual artifacts.
- The change aims to preserve view state when popping back to Home or Settings to reduce UI flicker and saved `Bundle` churn.

### Description
- Extended `AppHelper.buildNavOptions` to accept `saveState` and `restoreState` flags and to call `setPopUpTo(..., saveState)` and `setRestoreState(true)` when requested.
- Updated `MainActivity` navigation paths (`backToHomeScreen`, `goBackToSettings`) to attempt `popBackStack` first and only call `navigate` with `navOptionsFor(...)` when necessary, propagating `saveState=true` and `restoreState=true` to preserve existing destination state.
- Added a localized helper `navOptionsFor` that forwards `saveState`/`restoreState` to either a minimal `NavOptions` (when `preferenceHelper.disableAnimations` is true) or to `appHelper.buildNavOptions` with animations preserved.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979a46ad26483329f324bea548d71b2)