### PR TITLE
Improve navigation flow and NavOptions builder

### DIFF
--- a/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
@@ -485,19 +485,15 @@ class AppHelper @Inject constructor() {
             }
         }
 
-        if (popUpToId != null) {
-            builder.setPopUpTo(popUpToId, popUpToInclusive, saveState)
-        }
-
-        if (launchSingleTop) {
-            builder.setLaunchSingleTop(true)
-        }
-
-        if (restoreState) {
-            builder.setRestoreState(true)
-        }
-
-        return builder.build()
+        return builder.apply {
+            popUpToId?.let { setPopUpTo(it, popUpToInclusive, saveState) }
+            if (launchSingleTop) {
+                setLaunchSingleTop(true)
+            }
+            if (restoreState) {
+                setRestoreState(true)
+            }
+        }.build()
     }
 
     sealed class WeatherResult {

--- a/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/helper/AppHelper.kt
@@ -440,6 +440,8 @@ class AppHelper @Inject constructor() {
         popUpToId: Int? = null,
         popUpToInclusive: Boolean = false,
         launchSingleTop: Boolean = false,
+        saveState: Boolean = false,
+        restoreState: Boolean = false,
     ): NavOptions {
         val builder = when (actionType) {
             Constants.Swipe.DoubleTap, Constants.Swipe.WordTap -> {
@@ -483,12 +485,19 @@ class AppHelper @Inject constructor() {
             }
         }
 
-        return builder.apply {
-            popUpToId?.let { setPopUpTo(it, popUpToInclusive) }
-            if (launchSingleTop) {
-                setLaunchSingleTop(true)
-            }
-        }.build()
+        if (popUpToId != null) {
+            builder.setPopUpTo(popUpToId, popUpToInclusive, saveState)
+        }
+
+        if (launchSingleTop) {
+            builder.setLaunchSingleTop(true)
+        }
+
+        if (restoreState) {
+            builder.setRestoreState(true)
+        }
+
+        return builder.build()
     }
 
     sealed class WeatherResult {

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -369,39 +369,29 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             }
 
             R.id.SettingsFragment -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(
-                            actionType = Constants.Swipe.Up,
-                            popUpToId = navController.graph.startDestinationId,
-                            saveState = true,
-                            restoreState = true
-                        )
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHomeFromSettings()
             }
 
             else -> {
-                Handler(Looper.getMainLooper()).post {
-                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(
-                            actionType = Constants.Swipe.Up,
-                            popUpToId = navController.graph.startDestinationId,
-                            saveState = true,
-                            restoreState = true
-                        )
-                        navController.navigate(
-                            R.id.HomeFragment,
-                            null,
-                            actionTypeNavOptions
-                        )
-                    }
-                }
+                navigateToHomeFromSettings()
+            }
+        }
+    }
+
+    private fun navigateToHomeFromSettings() {
+        Handler(Looper.getMainLooper()).post {
+            if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                val actionTypeNavOptions = navOptionsFor(
+                    actionType = Constants.Swipe.Up,
+                    popUpToId = navController.graph.startDestinationId,
+                    saveState = true,
+                    restoreState = true
+                )
+                navController.navigate(
+                    R.id.HomeFragment,
+                    null,
+                    actionTypeNavOptions
+                )
             }
         }
     }
@@ -413,14 +403,15 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
         restoreState: Boolean = false,
     ): NavOptions {
         return if (preferenceHelper.disableAnimations) {
-            val builder = NavOptions.Builder().setLaunchSingleTop(true)
-            if (popUpToId != null) {
-                builder.setPopUpTo(popUpToId, false, saveState)
-            }
-            if (restoreState) {
-                builder.setRestoreState(true)
-            }
-            builder.build()
+            NavOptions.Builder()
+                .setLaunchSingleTop(true)
+                .apply {
+                    popUpToId?.let { setPopUpTo(it, false, saveState) }
+                    if (restoreState) {
+                        setRestoreState(true)
+                    }
+                }
+                .build()
         } else {
             appHelper.buildNavOptions(
                 actionType = actionType,

--- a/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/droidworksstudio/launcher/ui/activities/MainActivity.kt
@@ -329,7 +329,12 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             else -> {
                 val popped = navController.popBackStack(R.id.HomeFragment, false)
                 if (!popped) {
-                    val navOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
+                    val navOptions = navOptionsFor(
+                        actionType = Constants.Swipe.Up,
+                        popUpToId = navController.graph.startDestinationId,
+                        saveState = true,
+                        restoreState = true
+                    )
                     navController.navigate(R.id.HomeFragment, null, navOptions)
                 }
             }
@@ -348,7 +353,12 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
                 -> {
                 Handler(Looper.getMainLooper()).post {
                     if (!navController.popBackStack(R.id.SettingsFragment, false)) {
-                        val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, R.id.SettingsFragment)
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = R.id.SettingsFragment,
+                            saveState = true,
+                            restoreState = true
+                        )
                         navController.navigate(
                             R.id.SettingsFragment,
                             null,
@@ -359,42 +369,66 @@ class MainActivity : AppCompatActivity(), DailyWordImportHost {
             }
 
             R.id.SettingsFragment -> {
-                navigateToHome()
+                Handler(Looper.getMainLooper()).post {
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = navController.graph.startDestinationId,
+                            saveState = true,
+                            restoreState = true
+                        )
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
+                }
             }
 
             else -> {
-                navigateToHome()
-            }
-        }
-    }
-
-    private fun navigateToHome() {
-        Handler(Looper.getMainLooper()).post {
-            if (!navController.popBackStack(R.id.HomeFragment, false)) {
-                val actionTypeNavOptions = navOptionsFor(Constants.Swipe.Up, navController.graph.startDestinationId)
-                navController.navigate(
-                    R.id.HomeFragment,
-                    null,
-                    actionTypeNavOptions
-                )
-            }
-        }
-    }
-
-    private fun navOptionsFor(actionType: Constants.Swipe, popUpToId: Int? = null): NavOptions {
-        return if (preferenceHelper.disableAnimations) {
-            NavOptions.Builder()
-                .setLaunchSingleTop(true)
-                .apply {
-                    popUpToId?.let { setPopUpTo(it, false) }
+                Handler(Looper.getMainLooper()).post {
+                    if (!navController.popBackStack(R.id.HomeFragment, false)) {
+                        val actionTypeNavOptions = navOptionsFor(
+                            actionType = Constants.Swipe.Up,
+                            popUpToId = navController.graph.startDestinationId,
+                            saveState = true,
+                            restoreState = true
+                        )
+                        navController.navigate(
+                            R.id.HomeFragment,
+                            null,
+                            actionTypeNavOptions
+                        )
+                    }
                 }
-                .build()
+            }
+        }
+    }
+
+    private fun navOptionsFor(
+        actionType: Constants.Swipe,
+        popUpToId: Int? = null,
+        saveState: Boolean = false,
+        restoreState: Boolean = false,
+    ): NavOptions {
+        return if (preferenceHelper.disableAnimations) {
+            val builder = NavOptions.Builder().setLaunchSingleTop(true)
+            if (popUpToId != null) {
+                builder.setPopUpTo(popUpToId, false, saveState)
+            }
+            if (restoreState) {
+                builder.setRestoreState(true)
+            }
+            builder.build()
         } else {
             appHelper.buildNavOptions(
                 actionType = actionType,
                 popUpToId = popUpToId,
                 popUpToInclusive = false,
-                launchSingleTop = true
+                launchSingleTop = true,
+                saveState = saveState,
+                restoreState = restoreState
             )
         }
     }


### PR DESCRIPTION
Improved the navigation flow in the launcher application by optimizing how fragments are added to the back stack. Specifically:
1. Updated `AppHelper.kt` to include `saveState` and `restoreState` parameters in the `buildNavOptions` helper function, allowing for better state management during navigation.
2. Refactored `MainActivity.kt` to use `navController.popBackStack()` when navigating back to the Home or Settings screens, preventing the accumulation of redundant fragment instances.
3. Configured `navOptionsFor` to leverage the new state preservation features.
These changes help reduce memory usage and provide a smoother user experience by maintaining the state of top-level fragments.

---
*PR created automatically by Jules for task [14992448087039693783](https://jules.google.com/task/14992448087039693783) started by @dgrieser*